### PR TITLE
Bug fixes - frame counter, link checking and battery charge status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+main/configuration.h
+main/credentials.h

--- a/main/main.ino
+++ b/main/main.ino
@@ -263,6 +263,9 @@ void setup() {
   ttn_join();
   ttn_sf(LORAWAN_SF);
   ttn_adr(LORAWAN_ADR);
+  if(!LORAWAN_ADR){
+    LMIC_setLinkCheckMode(0); // Link check problematic if not using ADR. Must be set after join
+  }
 }
 
 void loop() {

--- a/main/screen.ino
+++ b/main/screen.ino
@@ -115,6 +115,7 @@ void screen_loop() {
         if (axp.isVbusRemoveIRQ()) {
             baChStatus = "No Charging";
         }
+    Serial.println(baChStatus); //Prints charging status to screen
         digitalWrite(2, !digitalRead(2));
         axp.clearIRQ();
     }

--- a/main/ttn.ino
+++ b/main/ttn.ino
@@ -230,9 +230,10 @@ void ttn_sf(unsigned char sf) {
 
 void ttn_adr(bool enabled) {
     LMIC_setAdrMode(enabled);
+    LMIC_setLinkCheckMode(!enabled);
 }
 
-void ttn_cnt(unsigned char num) {
+void ttn_cnt(uint32_t num) {
     LMIC_setSeqnoUp(num);
 }
 


### PR DESCRIPTION
Fixed frame counter (was unsigned char, should have been uint_32) which caused TTN to ignore device after 255 frames and rollover when frame count checks enabled

Turned off link checking when ADR not in use as it was forcing confirmed links

Added display of battery charging status

I think there may need to be a little more work on understanding of the link checking setup, but this works ok for now. Status when ADR is on should be checked - that's not been touched by changes.