### PR TITLE
PlatformIO support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,15 +17,26 @@ board = ttgo-t-beam
 framework = arduino
 
 ; note: we add src to our include search path so that lmic_project_config can override
-build_flags = -Wall -Wextra -Wno-missing-field-initializers -O3 -Wl,-Map,.pio/build/esp32/output.map -D CFG_us915 -D CFG_sx1276_radio
-; -DLOG_LOCAL_LEVEL=ESP_LOG_DEBUG -DCORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_DEBUG
+build_flags = -Wall -Wextra -Wno-missing-field-initializers -O3 -Wl,-Map,.pio/build/esp32/output.map 
+  ; -DLOG_LOCAL_LEVEL=ESP_LOG_DEBUG -DCORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_DEBUG
+
+  -D hal_init=LMICHAL_init           ; Workaround for naming conflict of function hal_init
+
+  ; Diable lmic_project_config.h, so that we can configure stuff here instead
+  -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS
+
+  ; Configure radio: enable exactly one of these
+  ; -D CFG_sx1272_radio=1            ; Use for SX1272 radio
+  -D CFG_sx1276_radio=1              ; Use for SX1276 radio
+
+  ; Configure region: enable exactly one of these
+  ; -D CFG_us915=1
+  -D CFG_eu868=1
 
 monitor_speed = 115200
 
 lib_deps =
   https://github.com/mcci-catena/arduino-lmic
-  TinyGPSPlus
-  ESP8266_SSD1306
-  AXP202X_Library
-  SPI
-
+  https://github.com/mikalhart/TinyGPSPlus
+  https://github.com/ThingPulse/esp8266-oled-ssd1306
+  https://github.com/lewisxhe/AXP202X_Library


### PR DESCRIPTION
This change makes the software compile on PlatformIO. There are three changes which
I perhaps should have split up:

1. There is a workaround for multiple definitions of `hal_init`, which has been [previously discussed](https://github.com/kizniche/ttgo-tbeam-ttn-tracker/issues/45).
2. `lib_deps` now refers to the relevant GitHub repos.
3. `lmic_project_config.h` is ignored; instead the radio info is now defined in `platformIio.ini` for ease of customization.